### PR TITLE
Don't set DeterministicSourcePaths from the build, let projects do it…

### DIFF
--- a/.idea/.idea.Nuke/.idea/.gitignore
+++ b/.idea/.idea.Nuke/.idea/.gitignore
@@ -11,3 +11,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/src/Nuke/DotNetCore/ICanTestWithDotNetCore.cs
+++ b/src/Nuke/DotNetCore/ICanTestWithDotNetCore.cs
@@ -8,15 +8,15 @@ namespace Rocket.Surgery.Nuke.DotNetCore;
 ///     Defines a `dotnet test` test run with code coverage via coverlet
 /// </summary>
 public interface ICanTestWithDotNetCore : IHaveCollectCoverage,
-                                          IHaveBuildTarget,
-                                          ITriggerCodeCoverageReports,
-                                          IComprehendTests,
-                                          IHaveTestArtifacts,
-                                          IHaveGitVersion,
-                                          IHaveSolution,
-                                          IHaveConfiguration,
-                                          IHaveOutputLogs,
-                                          ICan
+    IHaveBuildTarget,
+    ITriggerCodeCoverageReports,
+    IComprehendTests,
+    IHaveTestArtifacts,
+    IHaveGitVersion,
+    IHaveSolution,
+    IHaveConfiguration,
+    IHaveOutputLogs,
+    ICan
 {
     /// <summary>
     ///     dotnet test
@@ -50,13 +50,12 @@ public interface ICanTestWithDotNetCore : IHaveCollectCoverage,
                                                .EnableNoRestore()
                                                .EnableNoBuild()
                                                .SetLoggers("trx")
-                                               // DeterministicSourcePaths being true breaks coverlet!
-                                               .SetProperty("DeterministicSourcePaths", "false")
                                                .SetResultsDirectory(TestResultsDirectory)
                                                .When(
                                                     !CollectCoverage,
-                                                    x => x.SetProperty((string)"CollectCoverage", "true")
-                                                          .SetProperty("CoverageDirectory", CoverageDirectory)
+                                                    x => x
+                                                        .SetProperty((string)"CollectCoverage", "true")
+                                                        .SetProperty("CoverageDirectory", CoverageDirectory)
                                                 )
                                                .When(
                                                     CollectCoverage,

--- a/src/Nuke/DotNetCore/ICanTestWithDotNetCoreBuild.cs
+++ b/src/Nuke/DotNetCore/ICanTestWithDotNetCoreBuild.cs
@@ -9,15 +9,15 @@ namespace Rocket.Surgery.Nuke.DotNetCore;
 ///     Defines a `dotnet test` test run with code coverage via coverlet
 /// </summary>
 public interface ICanTestWithDotNetCoreBuild : IHaveCollectCoverage,
-                                               IHaveBuildTarget,
-                                               ITriggerCodeCoverageReports,
-                                               IComprehendTests,
-                                               IHaveTestArtifacts,
-                                               IHaveGitVersion,
-                                               IHaveSolution,
-                                               IHaveConfiguration,
-                                               IHaveOutputLogs,
-                                               ICan
+    IHaveBuildTarget,
+    ITriggerCodeCoverageReports,
+    IComprehendTests,
+    IHaveTestArtifacts,
+    IHaveGitVersion,
+    IHaveSolution,
+    IHaveConfiguration,
+    IHaveOutputLogs,
+    ICan
 {
     /// <summary>
     ///     dotnet test
@@ -45,28 +45,28 @@ public interface ICanTestWithDotNetCoreBuild : IHaveCollectCoverage,
                                   .EnsureRunSettingsExists(RunSettings)
                                   .Executes(
                                        () => DotNetTasks.DotNetTest(
-                                           s => s.SetProjectFile(Solution)
-                                                 .SetDefaultLoggers(LogsDirectory / "test.log")
-                                                 .SetGitVersionEnvironment(GitVersion)
-                                                 .EnableNoRestore()
-                                                 .SetLoggers("trx")
-                                                 .SetConfiguration(Configuration)
-                                                 .EnableNoBuild()
-                                                 // DeterministicSourcePaths being true breaks coverlet!
-                                                 .SetProperty("DeterministicSourcePaths", "false")
-                                                 .SetResultsDirectory(TestResultsDirectory)
-                                                 .When(
-                                                      !CollectCoverage,
-                                                      x => x.SetProperty((string)"CollectCoverage", "true")
-                                                            .SetProperty("CoverageDirectory", CoverageDirectory)
-                                                  )
-                                                 .When(
-                                                      CollectCoverage,
-                                                      x => x
-                                                          .SetProperty("CollectCoverage", "false")
-                                                          .SetDataCollector("XPlat Code Coverage")
-                                                          .SetSettingsFile(RunSettings)
-                                                  )
+                                           s => s
+                                               .SetProjectFile(Solution)
+                                               .SetDefaultLoggers(LogsDirectory / "test.log")
+                                               .SetGitVersionEnvironment(GitVersion)
+                                               .EnableNoRestore()
+                                               .SetLoggers("trx")
+                                               .SetConfiguration(Configuration)
+                                               .EnableNoBuild()
+                                               .SetResultsDirectory(TestResultsDirectory)
+                                               .When(
+                                                    !CollectCoverage,
+                                                    x => x
+                                                        .SetProperty((string)"CollectCoverage", "true")
+                                                        .SetProperty("CoverageDirectory", CoverageDirectory)
+                                                )
+                                               .When(
+                                                    CollectCoverage,
+                                                    x => x
+                                                        .SetProperty("CollectCoverage", "false")
+                                                        .SetDataCollector("XPlat Code Coverage")
+                                                        .SetSettingsFile(RunSettings)
+                                                )
                                        )
                                    )
                                   .CollectCoverage(TestResultsDirectory, CoverageDirectory);


### PR DESCRIPTION
… if needed.